### PR TITLE
Format email addresses, fix typo and make them clickable

### DIFF
--- a/_data/staff.yml
+++ b/_data/staff.yml
@@ -1,14 +1,14 @@
 lecturers:
   
   - name: Sebastian Proksch
-    email: S.Proksch at tudelft nl
+    email: S.Proksch@tudelft.nl
     function: Assistant Professor
     research_group: SERG, Assistant Professor
     research_group_url: https://serg.ewi.tudelft.nl
     photo: /assets/images/staff/SP.jpg
   
   - name: Luís Cruz
-    email: L.Cruz at tudelft nl
+    email: L.Cruz@tudelft.nl
     function: Assistant Professor
     research_group: SERG, Assistant Professor
     research_group_url: https://serg.ewi.tudelft.nl
@@ -17,10 +17,10 @@ lecturers:
 tas:
     
   - name: Cathrine Paulsen
-    email: c.r.paulsen at student tudelft nl
+    email: c.r.paulsen@student.tudelft.nl
     netid: cpaulsen
     
   - name: Dan Plamadeala
-    email: d.plamadeala at student tudelf nl
+    email: d.plamadeala@student.tudelft.nl
     netid: dplamadeala
 

--- a/course_info/staff.md
+++ b/course_info/staff.md
@@ -20,7 +20,7 @@ parent: Course Info
                 {{ lecturer.research_group }}
             </p>
         </td>
-        <td>{{ lecturer.email }}</td>
+        <td><a href="mailto:{{ lecturer.email }}">{{ lecturer.email }}</a></td>
     </tr>
     {% endfor %}
     </tbody>
@@ -49,7 +49,7 @@ parent: Course Info
                 <a href="https://mattermost.tudelft.nl/cse1105-2122-q3/messages/@{{ta.netid}}" style="color: #00A6D6; text-decoration: none;">
                     <img src="{{ '/assets/images/mattermost.png' | relative_url }}" style="max-width: 14px; vertical-align: middle;"/>
                     {{ ta.netid }}
-                </a> - ✉️ {{ ta.email }}
+                </a> - ✉️ <a href="mailto:{{ ta.email }}">{{ ta.email }}</a>
                 {% endif %}
             </p>
         </td>


### PR DESCRIPTION
## Issue
The formatting of the emails on https://se.ewi.tudelft.nl/remla/course_info/staff/ are not following standard email notation:

![image](https://user-images.githubusercontent.com/56686692/234555563-53f3bfbe-9a0f-425c-85a1-7960360a8e0e.png)

In case this is intended, please close this issue. Otherwise, I have changed the following:
* Formatted the emails using `@` and `.`, so `S.Proksch at tudelft nl` -> `S.Proksch@tudelft.nl`
* Wrapped them in a `<a href="mailto: ...">` to make them clickable, such that anyone can easily write an email with the correct address

**Update**: Additionally, also fixed the emails of the TAs (including typo) in similar fashion to the above.
![image](https://user-images.githubusercontent.com/56686692/236619377-b5f3354f-0000-4e72-8a5f-4c4694ec27b9.png)

> Note: changes have not been tested locally 

