### PR TITLE
Fix SMS Spam project link in MLQuality

### DIFF
--- a/material/ML_code_quality/dslinter.md
+++ b/material/ML_code_quality/dslinter.md
@@ -9,7 +9,7 @@ nav_order: 2
 # {{page.title}}
 
 This is a basic script to set up ds-linter to enable pylint to find ML-specific code smells.
-Use the [sms project]({{"/remla/material/projects/sms-spam/" | absolute_path}}) as a base project. 
+Use the [sms project]({% link /remla/material/projects/sms-spam/ %}) as a base project. 
 We assume you already executed the [pylint guide](./pylint).
 
 **Install dslinter.**

--- a/material/ML_code_quality/dslinter.md
+++ b/material/ML_code_quality/dslinter.md
@@ -9,7 +9,7 @@ nav_order: 2
 # {{page.title}}
 
 This is a basic script to set up ds-linter to enable pylint to find ML-specific code smells.
-Use the [sms project]({{"/material/projects/sms-spam/" | absolute_path}}) as a base project. 
+Use the [sms project]({{"/remla/material/projects/sms-spam/" | absolute_path}}) as a base project. 
 We assume you already executed the [pylint guide](./pylint).
 
 **Install dslinter.**

--- a/material/ML_code_quality/pylint.md
+++ b/material/ML_code_quality/pylint.md
@@ -9,7 +9,7 @@ nav_order: 1
 # {{page.title}}
 
 This is a basic script to set up and use pylint.
-Use the [sms project]({{"/material/projects/sms-spam/" | absolute_path}}) as a base project.
+Use the [sms project]({{"/remla/material/projects/sms-spam/" | absolute_path}}) as a base project.
 
 *Note: do not forget to use a virtual environment, install dependencies, etc.*
 

--- a/material/ML_code_quality/pylint.md
+++ b/material/ML_code_quality/pylint.md
@@ -9,7 +9,7 @@ nav_order: 1
 # {{page.title}}
 
 This is a basic script to set up and use pylint.
-Use the [sms project]({{"/remla/material/projects/sms-spam/" | absolute_path}}) as a base project.
+Use the [sms project]({% link /remla/material/projects/sms-spam/ %}) as a base project.
 
 *Note: do not forget to use a virtual environment, install dependencies, etc.*
 


### PR DESCRIPTION
## Issue

The link referring to the SMS Spam project in the following places is not working properly:

![image](https://github.com/SERG-Delft/remla/assets/56686692/cde95ec3-66b4-4d68-aebe-3831f397f246)

![image](https://github.com/SERG-Delft/remla/assets/56686692/5f666cc2-3930-4b89-9e2b-64a3235109b8)

It results in https://se.ewi.tudelft.nl/material/projects/sms-spam/, a 404:

![image](https://github.com/SERG-Delft/remla/assets/56686692/5968a5a2-56ee-45cc-975c-4a10c95f8549)

## Solution

Changed the link to include the `/remla` prefix, which leads to the right place: https://se.ewi.tudelft.nl/remla/material/projects/sms-spam/.
